### PR TITLE
Update README - add link for Scoop install

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You should therefore install it manually, via Git:
     * OS X: `~/Library/Application\ Support/Sublime\ Text\ 3/Packages/`
     * Linux: `~/.config/sublime-text-3/Packages/`
     * Windows: `%APPDATA%\Sublime Text 3\Packages\`
+    * Windows (Scoop): `%USERPROFILE%\scoop\apps\sublime-text\current\Packages`
 2. From that directory, invoke Git to clone this repository into the `PML` subdirectory:
 
         git clone https://github.com/tajmone/Sublime-PML PML


### PR DESCRIPTION
Add link for the "Packages" folder when Sublime Text is installed via the Scoop package installer.