### PR TITLE
Update README - correct "Packages" location

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You should therefore install it manually, via Git:
     * OS X: `~/Library/Application\ Support/Sublime\ Text\ 3/Packages/`
     * Linux: `~/.config/sublime-text-3/Packages/`
     * Windows: `%APPDATA%\Sublime Text 3\Packages\`
-    * Windows (Scoop): `%USERPROFILE%\scoop\apps\sublime-text\current\Packages`
+    * Windows (Scoop): `%USERPROFILE%\scoop\persist\sublime-text\Data\Packages`
 2. From that directory, invoke Git to clone this repository into the `PML` subdirectory:
 
         git clone https://github.com/tajmone/Sublime-PML PML


### PR DESCRIPTION
Hi Tristano,

I have been using the Sublime Text editor for the past day or so and have discovered that the "Packages" location for the Scoop install is incorrect.

The menu option `Preferences => Browse Packages...` opens the correct folder: `%USERPROFILE%\scoop\persist\sublime-text\Data\Packages`.

The `git clone https://github.com/tajmone/Sublime-PML PML` instruction works correctly in this folder.

I have made the necessary change in this PR.

Kind Regards,
Liam